### PR TITLE
Pass a type error when the URL is not an image URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,19 +28,27 @@ module.exports = function(imgUrl, done) {
   var req = client.get(options, function(response) {
     var buffer = new Buffer([]);
     var dimensions;
+    var imageTypeDetectionError;
 
     response
     .on('data', function(chunk) {
       buffer = Buffer.concat([buffer, chunk]);
       try {
         dimensions = sizeOf(buffer);
-        req.abort();
-      } catch(e) {}
+      } catch (e) {
+        imageTypeDetectionError = e;
+        return;
+      }
+      req.abort();
     })
     .on('error', function(err) {
       done(err);
     })
     .on('end', function() {
+      if (!dimensions) {
+        done(imageTypeDetectionError);
+        return;
+      }
       done(null, dimensions, buffer.length);
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -35,17 +35,17 @@ describe('http-image-size', function() {
     });
   });
   it('should throw an error when the URL doesn\'t have http(s) scheme.', function() {
-    assert.throws(size.bind(null, 'ftp://dummy.com/foo.jpg', function() {}));
+    assert.throws(size.bind(null, 'ftp://dummy.com/foo.jpg', function() {}), Error);
   });
   it('should pass an error when the image is not found.', function(done) {
     size('http://jo.github.io/http-image-size/dummy.gif', function(err) {
-      assert.ifError(err);
+      assert.throws(assert.ifError.bind(null, err));
       done();
     });
   });
-  it('should pass an error when the URL is not an image URL.', function(done) {
+  it('should pass an type error when the URL is not an image URL.', function(done) {
     size('http://example.com/', function(err) {
-      assert.ifError(err);
+      assert.throws(assert.ifError.bind(null, err), TypeError);
       done();
     });
   });


### PR DESCRIPTION
Currently http-image-size does not pass an error to the callback function when it fails to detect image type, or the URL is not an image URL.
